### PR TITLE
NewsCardコンポーネントを並べて表示するコンポーネントを実装

### DIFF
--- a/src/components/molecules/NewsCardList/index.stories.tsx
+++ b/src/components/molecules/NewsCardList/index.stories.tsx
@@ -26,7 +26,7 @@ export const General: ComponentStoryObj<typeof NewsCardList> = {
         ],
       },
       {
-        key: '57c3ff77-d8bd-41bb-86e3-4526e1b2186c',
+        key: '57c3ff77-d8bd-41bb-86e3-4526e1b2186e',
         title: 'メンテナンスのお知らせ',
         date: new Date('2017-07-21T17:32:28Z'),
         href: '#',
@@ -42,7 +42,7 @@ export const General: ComponentStoryObj<typeof NewsCardList> = {
         ],
       },
       {
-        key: '57c3ff77-d8bd-41bb-86e3-4526e1b2186c',
+        key: '57c3ff77-d8bd-41bb-86e3-4526e1b2186d',
         title: 'メンテナンスのお知らせ',
         date: new Date('2017-07-21T17:32:28Z'),
         href: '#',

--- a/src/components/molecules/NewsCardList/index.stories.tsx
+++ b/src/components/molecules/NewsCardList/index.stories.tsx
@@ -1,0 +1,62 @@
+import { NewsCardList } from 'src/components/molecules/NewsCardList/index';
+import { ComponentMeta, ComponentStoryObj } from '@storybook/react';
+
+export default {
+  component: NewsCardList,
+  title: 'molecules/NewsCardList',
+} as ComponentMeta<typeof NewsCardList>;
+
+export const General: ComponentStoryObj<typeof NewsCardList> = {
+  args: {
+    cards: [
+      {
+        key: '57c3ff77-d8bd-41bb-86e3-4526e1b2186c',
+        title: 'メンテナンスのお知らせ',
+        date: new Date('2017-07-21T17:32:28Z'),
+        href: '#',
+        tags: [
+          {
+            name: '重要',
+            backGroundColor: 'red',
+          },
+          {
+            name: 'メンテナンス',
+            backGroundColor: 'yellow',
+          },
+        ],
+      },
+      {
+        key: '57c3ff77-d8bd-41bb-86e3-4526e1b2186c',
+        title: 'メンテナンスのお知らせ',
+        date: new Date('2017-07-21T17:32:28Z'),
+        href: '#',
+        tags: [
+          {
+            name: '重要',
+            backGroundColor: 'red',
+          },
+          {
+            name: 'メンテナンス',
+            backGroundColor: 'yellow',
+          },
+        ],
+      },
+      {
+        key: '57c3ff77-d8bd-41bb-86e3-4526e1b2186c',
+        title: 'メンテナンスのお知らせ',
+        date: new Date('2017-07-21T17:32:28Z'),
+        href: '#',
+        tags: [
+          {
+            name: '重要',
+            backGroundColor: 'red',
+          },
+          {
+            name: 'メンテナンス',
+            backGroundColor: 'yellow',
+          },
+        ],
+      },
+    ],
+  },
+};

--- a/src/components/molecules/NewsCardList/index.tsx
+++ b/src/components/molecules/NewsCardList/index.tsx
@@ -1,0 +1,19 @@
+import { ComponentProps, VFC } from 'react';
+import { NewsCard } from 'src/components/molecules/NewsCard';
+import { Stack } from '@chakra-ui/react';
+
+interface Card extends ComponentProps<typeof NewsCard> {
+  key: string;
+}
+
+interface NewsCardProps {
+  cards: Card[];
+}
+
+export const NewsCardList: VFC<NewsCardProps> = ({ cards }) => (
+  <Stack>
+    {cards.map((card) => (
+      <NewsCard {...card} />
+    ))}
+  </Stack>
+);


### PR DESCRIPTION
ブランチの派生元が #5 になってしまっていた #6 の修正版です。

- NewsCardListコンポーネントを実装

figmaを見るとリンクが無いNewsCardが必要みたいなので、それは別途プルリクを出します。